### PR TITLE
Dockerfile: make multistage, add nginx mime.types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine
+FROM golang:1.24-alpine AS build
 
 WORKDIR /usr/src/app
 
@@ -8,5 +8,9 @@ RUN go mod download && go mod verify
 
 COPY . .
 RUN go build -v -o /usr/local/bin/app ./main.go
+
+FROM alpine:3.22.1
+
+COPY --from=build /usr/local/bin/app /usr/local/bin/app
 
 CMD ["app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,14 @@ RUN go mod download && go mod verify
 COPY . .
 RUN go build -v -o /usr/local/bin/app ./main.go
 
+FROM alpine:3.22.1 AS mimetypes
+
+RUN apk add --no-cache apache2
+
 FROM alpine:3.22.1
 
+# Make more mimetypes available to https://pkg.go.dev/mime#TypeByExtension
+COPY --from=mimetypes /etc/apache2/mime.types /etc/apache2/mime.types
 COPY --from=build /usr/local/bin/app /usr/local/bin/app
 
 CMD ["app"]


### PR DESCRIPTION
Following our convo in https://raru.re/@nadia/114890315363378644, this should fix the `Content-type` header being empty for files with `mp4` extension.